### PR TITLE
Revamp landing hero with fullpage scroll transition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,202 @@
-import { useMemo } from 'react';
-import HeroSection from './components/HeroSection';
-import ServicesSection from './components/ServicesSection';
-import ExperienceSection from './components/ExperienceSection';
-import GallerySection from './components/GallerySection';
-import InquirySection from './components/InquirySection';
-import MapSection from './components/MapSection';
-import Footer from './components/Footer';
-import FloatingCTA from './components/FloatingCTA';
+import { useEffect, useMemo, useState } from 'react';
 import './styles/app.css';
 
+type HeroSlide =
+  | {
+      id: string;
+      type: 'logo';
+      title: string;
+      subtitle: string;
+      description: string;
+    }
+  | {
+      id: string;
+      type: 'advantages';
+      title: string;
+      highlights: string[];
+    }
+  | {
+      id: string;
+      type: 'staff';
+      title: string;
+      members: { name: string; role: string }[];
+    };
+
+const DISPLAY_DURATION = 3200;
+const FADE_DURATION = 800;
+
 function App() {
-  const currentYear = useMemo(() => new Date().getFullYear(), []);
+  const slides = useMemo<HeroSlide[]>(
+    () => [
+      {
+        id: 'logo-primary',
+        type: 'logo',
+        title: '24온동물의료센터',
+        subtitle: '24ON Animal Medical Center',
+        description: '24시간 365일 응급 및 전문 진료를 제공하는 프리미엄 동물의료센터',
+      },
+      {
+        id: 'advantages',
+        type: 'advantages',
+        title: '24ON의 장점',
+        highlights: [
+          '분과별 전문의로 구성된 협진 시스템',
+          '첨단 장비와 체계적인 24시간 모니터링',
+          '진료부터 회복까지 반려동물과 보호자 중심의 케어',
+        ],
+      },
+      {
+        id: 'staff',
+        type: 'staff',
+        title: '의료진 소개',
+        members: [
+          { name: '김태윤 대표원장', role: '내과 전문의 / 응급의학' },
+          { name: '박서현 원장', role: '외과 전문의 / 정형외과' },
+          { name: '이도현 원장', role: '영상의학 / 재활치료' },
+        ],
+      },
+      {
+        id: 'logo-secondary',
+        type: 'logo',
+        title: '24온동물의료센터',
+        subtitle: '당신의 반려동물에게 최고의 시간을 선물합니다',
+        description: '응급부터 전문 진료까지 24시간 한결같이 곁을 지키는 의료 파트너',
+      },
+    ],
+    [],
+  );
+
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const [activeSlide, setActiveSlide] = useState(0);
+  const [isFading, setIsFading] = useState(false);
+
+  useEffect(() => {
+    const updateProgress = () => {
+      const viewportHeight = window.innerHeight || 1;
+      const progress = Math.min(Math.max(window.scrollY / viewportHeight, 0), 1);
+      setScrollProgress(progress);
+    };
+
+    updateProgress();
+    window.addEventListener('scroll', updateProgress, { passive: true });
+    window.addEventListener('resize', updateProgress);
+
+    return () => {
+      window.removeEventListener('scroll', updateProgress);
+      window.removeEventListener('resize', updateProgress);
+    };
+  }, []);
+
+  useEffect(() => {
+    let fadeTimer: ReturnType<typeof setTimeout> | undefined;
+    const displayTimer = setTimeout(() => {
+      setIsFading(true);
+      fadeTimer = setTimeout(() => {
+        setActiveSlide((prev) => (prev + 1) % slides.length);
+        setIsFading(false);
+      }, FADE_DURATION);
+    }, DISPLAY_DURATION);
+
+    return () => {
+      clearTimeout(displayTimer);
+      if (fadeTimer) {
+        clearTimeout(fadeTimer);
+      }
+    };
+  }, [activeSlide, slides.length]);
+
+  const progress = Math.min(Math.max(scrollProgress, 0), 1);
+  const heroTranslate = -progress * 28;
+  const infoTranslate = Math.max(100 - progress * 180, -90);
+
+  const renderSlideContent = () => {
+    const slide = slides[activeSlide];
+
+    if (!slide) {
+      return null;
+    }
+
+    switch (slide.type) {
+      case 'logo':
+        return (
+          <div className="hero-slide hero-slide-logo">
+            <div className="hero-logo-mark" aria-hidden="true">
+              <span>24</span>
+              <span>ON</span>
+            </div>
+            <h1>{slide.title}</h1>
+            <p className="hero-subtitle">{slide.subtitle}</p>
+            <p className="hero-description">{slide.description}</p>
+          </div>
+        );
+      case 'advantages':
+        return (
+          <div className="hero-slide hero-slide-advantages">
+            <span className="hero-badge">Why 24ON</span>
+            <h2>{slide.title}</h2>
+            <ul>
+              {slide.highlights.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        );
+      case 'staff':
+        return (
+          <div className="hero-slide hero-slide-staff">
+            <h2>{slide.title}</h2>
+            <div className="hero-staff-list">
+              {slide.members.map((member) => (
+                <div className="hero-staff-card" key={member.name}>
+                  <span className="hero-staff-name">{member.name}</span>
+                  <span className="hero-staff-role">{member.role}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
-    <div className="app-container">
-      <HeroSection />
-      <ServicesSection />
-      <ExperienceSection />
-      <GallerySection />
-      <InquirySection />
-      <MapSection />
-      <Footer currentYear={currentYear} />
-      <FloatingCTA />
+    <div className="page-root">
+      <div className="scroll-stage">
+        <div className="sticky-scenes">
+          <section
+            className={`scene scene-hero ${isFading ? 'is-fading' : 'is-visible'}`}
+            style={{ transform: `translateY(${heroTranslate}vh)` }}
+          >
+            <div className={`hero-content ${isFading ? 'is-fading' : 'is-visible'}`}>{renderSlideContent()}</div>
+          </section>
+          <section className="scene scene-info" style={{ transform: `translateY(${infoTranslate}vh)` }}>
+            <div className="info-content">
+              <span className="info-badge">24ON CARE SYSTEM</span>
+              <h2>한층 더 진화한 프리미엄 동물의료 서비스</h2>
+              <p>
+                24온동물의료센터는 보호자와 반려동물이 안심할 수 있는 진료 환경을 만들기 위해
+                응급·내과·외과·재활 등 다양한 진료 과목이 긴밀하게 협력합니다. 두 번째 화면에서는
+                병원 소개와 이용 안내, 그리고 세심한 케어 철학을 빠르게 만나볼 수 있습니다.
+              </p>
+              <div className="info-grid">
+                <div className="info-card">
+                  <h3>365일 24시간</h3>
+                  <p>야간과 주말에도 전문의가 상주하며 응급 상황에 즉시 대응합니다.</p>
+                </div>
+                <div className="info-card">
+                  <h3>첨단 진단 장비</h3>
+                  <p>CT, MRI, 내시경 등 최첨단 장비로 정확한 진단과 맞춤형 치료가 이루어집니다.</p>
+                </div>
+                <div className="info-card">
+                  <h3>원스톱 케어</h3>
+                  <p>상담부터 재활, 홈케어 가이드까지 보호자와 함께하는 전인 케어를 제공합니다.</p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,13 +1,310 @@
-.app-container {
-  display: flex;
-  flex-direction: column;
-  gap: 6rem;
-  padding-bottom: 6rem;
+.page-root {
+  min-height: 200vh;
+  background: radial-gradient(circle at top left, rgba(94, 136, 255, 0.28), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(255, 90, 118, 0.25), transparent 55%),
+    linear-gradient(120deg, #040b1b 0%, #041729 48%, #071f33 100%);
+  color: rgba(236, 241, 255, 0.92);
+  overflow: hidden;
 }
 
-@media (max-width: 768px) {
-  .app-container {
-    gap: 4rem;
-    padding-bottom: 4rem;
+.scroll-stage {
+  height: 200vh;
+}
+
+.sticky-scenes {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.scene {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 6vw, 6rem);
+  transition: transform 0.18s ease-out;
+  will-change: transform;
+}
+
+.scene-hero {
+  z-index: 3;
+  background:
+    linear-gradient(140deg, rgba(3, 15, 36, 0.92) 0%, rgba(8, 44, 72, 0.85) 55%, rgba(17, 74, 102, 0.78) 100%),
+    url('https://images.unsplash.com/photo-1555685812-4b74353f1f86?auto=format&fit=crop&w=1800&q=80') center / cover
+      no-repeat;
+}
+
+.scene-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(4, 11, 27, 0.65), rgba(4, 15, 36, 0));
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  max-width: 760px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: clamp(360px, 52vh, 560px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.hero-content.is-fading {
+  opacity: 0;
+  transform: translateY(-14px);
+}
+
+.hero-content.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hero-slide {
+  display: grid;
+  gap: clamp(1rem, 1.8vw, 1.8rem);
+  justify-items: center;
+}
+
+.hero-slide h1,
+.hero-slide h2 {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.hero-slide h1 {
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+}
+
+.hero-slide h2 {
+  font-size: clamp(2rem, 3vw, 2.8rem);
+}
+
+.hero-slide p {
+  margin: 0;
+  line-height: 1.6;
+  font-size: clamp(1rem, 1.3vw, 1.2rem);
+  color: rgba(223, 232, 255, 0.84);
+}
+
+.hero-slide-logo {
+  gap: clamp(1.2rem, 2vw, 2rem);
+}
+
+.hero-logo-mark {
+  display: grid;
+  place-items: center;
+  padding: clamp(1.6rem, 2.4vw, 2.8rem);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(80, 115, 255, 0.38), rgba(111, 207, 255, 0.25));
+  font-size: clamp(1.4rem, 2.2vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #fff;
+  box-shadow: 0 24px 65px rgba(12, 33, 68, 0.42);
+  min-width: clamp(150px, 21vw, 220px);
+}
+
+.hero-logo-mark span {
+  display: block;
+}
+
+.hero-subtitle {
+  font-size: clamp(1rem, 1.4vw, 1.3rem);
+  font-weight: 500;
+  color: rgba(198, 213, 255, 0.85);
+}
+
+.hero-description {
+  max-width: 520px;
+}
+
+.hero-slide-advantages ul {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.hero-slide-advantages li {
+  position: relative;
+  padding-left: 1.6rem;
+  font-size: clamp(1rem, 1.3vw, 1.15rem);
+  color: rgba(227, 237, 255, 0.9);
+}
+
+.hero-slide-advantages li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6ac8ff, #8fe5ff);
+  box-shadow: 0 0 12px rgba(116, 213, 255, 0.55);
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.6rem;
+  border-radius: 999px;
+  background: rgba(120, 180, 255, 0.18);
+  color: rgba(198, 221, 255, 0.9);
+  font-size: 0.85rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.hero-slide-staff {
+  gap: clamp(1.4rem, 2vw, 2rem);
+}
+
+.hero-staff-list {
+  display: grid;
+  gap: 1rem;
+  width: min(520px, 80vw);
+}
+
+.hero-staff-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1.1rem 1.4rem;
+  border-radius: 20px;
+  background: rgba(10, 28, 60, 0.58);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(126, 170, 255, 0.22);
+  text-align: left;
+}
+
+.hero-staff-name {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.hero-staff-role {
+  color: rgba(205, 219, 255, 0.76);
+  font-size: 0.95rem;
+}
+
+.scene-info {
+  z-index: 4;
+  background:
+    linear-gradient(155deg, rgba(13, 22, 42, 0.92) 0%, rgba(8, 30, 56, 0.88) 45%, rgba(7, 18, 46, 0.9) 100%),
+    url('https://images.unsplash.com/photo-1573497491208-6b1acb260507?auto=format&fit=crop&w=1800&q=80') center /
+      cover no-repeat;
+  box-shadow: inset 0 0 0 1px rgba(104, 151, 255, 0.08);
+}
+
+.scene-info::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(4, 11, 27, 0.72), rgba(4, 12, 28, 0.2));
+  pointer-events: none;
+}
+
+.info-content {
+  position: relative;
+  z-index: 2;
+  max-width: 840px;
+  text-align: left;
+  display: grid;
+  gap: clamp(1.2rem, 2.5vw, 2.4rem);
+  color: rgba(227, 235, 255, 0.94);
+}
+
+.info-content h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3.2vw, 3.2rem);
+  font-weight: 700;
+}
+
+.info-content p {
+  margin: 0;
+  font-size: clamp(1rem, 1.25vw, 1.15rem);
+  line-height: 1.7;
+  color: rgba(208, 222, 255, 0.82);
+}
+
+.info-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(125, 199, 255, 0.18);
+  color: rgba(204, 224, 255, 0.9);
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+}
+
+.info-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.info-card {
+  padding: 1.4rem 1.6rem;
+  border-radius: 20px;
+  background: rgba(10, 28, 54, 0.7);
+  border: 1px solid rgba(126, 170, 255, 0.2);
+  backdrop-filter: blur(6px);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.info-card h3 {
+  margin: 0;
+  font-size: clamp(1.1rem, 1.5vw, 1.4rem);
+  font-weight: 600;
+  color: rgba(230, 239, 255, 0.94);
+}
+
+.info-card p {
+  font-size: clamp(0.95rem, 1.1vw, 1.05rem);
+  color: rgba(200, 215, 245, 0.78);
+  line-height: 1.6;
+}
+
+@media (max-width: 1024px) {
+  .info-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .hero-content {
+    min-height: clamp(320px, 68vh, 540px);
+  }
+
+  .hero-logo-mark {
+    min-width: 140px;
+    padding: 1.6rem 1.8rem;
+  }
+
+  .hero-staff-list {
+    width: 100%;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .scene {
+    padding: clamp(1.8rem, 8vw, 3rem);
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,17 +1,10 @@
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  --color-primary: #65b9b6;
-  --color-secondary: #4f5d8c;
-  --color-accent: #f8c9d4;
-  --color-dark: #1f2743;
-  --color-light: #f4f7fb;
-  --color-muted: #68718f;
-  --shadow-soft: 0 28px 70px rgba(80, 104, 146, 0.18);
-  background-color: var(--color-light);
-  color: var(--color-dark);
+  background-color: #040916;
+  color: rgba(230, 236, 255, 0.95);
 }
 
 * {
@@ -21,11 +14,9 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background:
-    linear-gradient(135deg, rgba(101, 185, 182, 0.12) 0%, rgba(101, 185, 182, 0) 40%),
-    linear-gradient(320deg, rgba(248, 201, 212, 0.28) 0%, rgba(248, 201, 212, 0) 55%),
-    var(--color-light);
-  color: var(--color-dark);
+  background: #040916;
+  color: rgba(230, 236, 255, 0.95);
+  overflow-x: hidden;
 }
 
 a {
@@ -36,58 +27,4 @@ a {
 img {
   max-width: 100%;
   display: block;
-}
-
-.section-heading {
-  text-align: center;
-  max-width: 720px;
-  margin: 0 auto 3rem;
-}
-
-.section-heading h2 {
-  font-size: clamp(2rem, 2.8vw, 2.8rem);
-  margin-bottom: 1rem;
-  font-weight: 800;
-}
-
-.section-description {
-  color: var(--color-muted);
-  font-size: 1.05rem;
-  line-height: 1.7;
-}
-
-.section-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1.4rem;
-  border-radius: 999px;
-  background: rgba(101, 185, 182, 0.15);
-  color: var(--color-primary);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.app-container {
-  overflow-x: hidden;
-}
-
-@keyframes floatUpDown {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-8px);
-  }
-}
-
-@media (max-width: 768px) {
-  .section-heading {
-    padding: 0 1.5rem;
-  }
-
-  .section-description {
-    font-size: 1rem;
-  }
 }


### PR DESCRIPTION
## Summary
- replace the multi-section layout with a two-scene full screen experience that mimics the 24ON landing page
- add an auto-advancing hero sequence with logo, strengths, and staff highlights that fade between states
- restyle global and scene-specific backgrounds for the dark, immersive presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da184d2dc0832da19e1ce0302114d7