### PR TITLE
Expose full landing content and finalize hero slider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
+import ExperienceSection from './components/ExperienceSection';
+import FloatingCTA from './components/FloatingCTA';
+import Footer from './components/Footer';
+import GallerySection from './components/GallerySection';
+import HeroSection from './components/HeroSection';
+import InquirySection from './components/InquirySection';
+import MapSection from './components/MapSection';
+import ServicesSection from './components/ServicesSection';
 import './styles/app.css';
 
 type HeroSlide =
@@ -69,6 +77,7 @@ function App() {
   const [scrollProgress, setScrollProgress] = useState(0);
   const [activeSlide, setActiveSlide] = useState(0);
   const [isFading, setIsFading] = useState(false);
+  const [hasCompletedSlides, setHasCompletedSlides] = useState(false);
 
   useEffect(() => {
     const updateProgress = () => {
@@ -88,12 +97,27 @@ function App() {
   }, []);
 
   useEffect(() => {
+    if (hasCompletedSlides) {
+      return undefined;
+    }
+
     let fadeTimer: ReturnType<typeof setTimeout> | undefined;
     const displayTimer = setTimeout(() => {
       setIsFading(true);
       fadeTimer = setTimeout(() => {
-        setActiveSlide((prev) => (prev + 1) % slides.length);
+        let reachedEnd = false;
+        setActiveSlide((prev) => {
+          const nextIndex = prev + 1;
+          if (nextIndex >= slides.length) {
+            reachedEnd = true;
+            return prev;
+          }
+          return nextIndex;
+        });
         setIsFading(false);
+        if (reachedEnd) {
+          setHasCompletedSlides(true);
+        }
       }, FADE_DURATION);
     }, DISPLAY_DURATION);
 
@@ -103,7 +127,7 @@ function App() {
         clearTimeout(fadeTimer);
       }
     };
-  }, [activeSlide, slides.length]);
+  }, [activeSlide, slides.length, hasCompletedSlides]);
 
   const progress = Math.min(Math.max(scrollProgress, 0), 1);
   const heroTranslate = -progress * 28;
@@ -197,6 +221,18 @@ function App() {
           </section>
         </div>
       </div>
+
+      <main className="page-content">
+        <HeroSection />
+        <ServicesSection />
+        <ExperienceSection />
+        <GallerySection />
+        <InquirySection />
+        <MapSection />
+      </main>
+
+      <Footer currentYear={new Date().getFullYear()} />
+      <FloatingCTA />
     </div>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,13 +1,14 @@
 .page-root {
-  min-height: 200vh;
+  min-height: 100vh;
   background: radial-gradient(circle at top left, rgba(94, 136, 255, 0.28), transparent 50%),
     radial-gradient(circle at bottom right, rgba(255, 90, 118, 0.25), transparent 55%),
     linear-gradient(120deg, #040b1b 0%, #041729 48%, #071f33 100%);
   color: rgba(236, 241, 255, 0.92);
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 .scroll-stage {
+  position: relative;
   height: 200vh;
 }
 
@@ -16,6 +17,15 @@
   top: 0;
   height: 100vh;
   overflow: hidden;
+}
+
+.page-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(4rem, 10vw, 7rem);
+  padding-block: clamp(4rem, 10vw, 7rem);
+  background: linear-gradient(180deg, rgba(4, 9, 22, 0) 0%, rgba(4, 9, 22, 0.92) 18%, rgba(4, 9, 22, 0.98) 100%);
 }
 
 .scene {


### PR DESCRIPTION
## Summary
- allow the hero slider sequence to run through every slide and stop on the finale
- keep the sticky hero experience while revealing the full landing page sections and footer
- add layout styling so the below-the-fold content and floating CTA display correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da1cecd5b4832d8a6a587d116b2cef