### PR TITLE
Remove hero slide fade transition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,6 @@ type HeroSlide =
     };
 
 const DISPLAY_DURATION = 3200;
-const FADE_DURATION = 800;
 
 function App() {
   const slides = useMemo<HeroSlide[]>(
@@ -76,7 +75,6 @@ function App() {
 
   const [scrollProgress, setScrollProgress] = useState(0);
   const [activeSlide, setActiveSlide] = useState(0);
-  const [isFading, setIsFading] = useState(false);
   const [hasCompletedSlides, setHasCompletedSlides] = useState(false);
 
   useEffect(() => {
@@ -101,31 +99,23 @@ function App() {
       return undefined;
     }
 
-    let fadeTimer: ReturnType<typeof setTimeout> | undefined;
     const displayTimer = setTimeout(() => {
-      setIsFading(true);
-      fadeTimer = setTimeout(() => {
-        let reachedEnd = false;
-        setActiveSlide((prev) => {
-          const nextIndex = prev + 1;
-          if (nextIndex >= slides.length) {
-            reachedEnd = true;
-            return prev;
-          }
-          return nextIndex;
-        });
-        setIsFading(false);
-        if (reachedEnd) {
-          setHasCompletedSlides(true);
+      let reachedEnd = false;
+      setActiveSlide((prev) => {
+        const nextIndex = prev + 1;
+        if (nextIndex >= slides.length) {
+          reachedEnd = true;
+          return prev;
         }
-      }, FADE_DURATION);
+        return nextIndex;
+      });
+      if (reachedEnd) {
+        setHasCompletedSlides(true);
+      }
     }, DISPLAY_DURATION);
 
     return () => {
       clearTimeout(displayTimer);
-      if (fadeTimer) {
-        clearTimeout(fadeTimer);
-      }
     };
   }, [activeSlide, slides.length, hasCompletedSlides]);
 
@@ -188,11 +178,8 @@ function App() {
     <div className="page-root">
       <div className="scroll-stage">
         <div className="sticky-scenes">
-          <section
-            className={`scene scene-hero ${isFading ? 'is-fading' : 'is-visible'}`}
-            style={{ transform: `translateY(${heroTranslate}vh)` }}
-          >
-            <div className={`hero-content ${isFading ? 'is-fading' : 'is-visible'}`}>{renderSlideContent()}</div>
+          <section className="scene scene-hero" style={{ transform: `translateY(${heroTranslate}vh)` }}>
+            <div className="hero-content">{renderSlideContent()}</div>
           </section>
           <section className="scene scene-info" style={{ transform: `translateY(${infoTranslate}vh)` }}>
             <div className="info-content">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -64,17 +64,6 @@
   align-items: center;
   justify-content: center;
   min-height: clamp(360px, 52vh, 560px);
-  transition: opacity 0.8s ease, transform 0.8s ease;
-}
-
-.hero-content.is-fading {
-  opacity: 0;
-  transform: translateY(-14px);
-}
-
-.hero-content.is-visible {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 .hero-slide {


### PR DESCRIPTION
## Summary
- remove the hero slide fade timing logic so slides swap immediately
- simplify the hero content styles by dropping fade transition classes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da1f406c8c832d9129fbdf14133d7b