### PR TITLE
Fix blank screen after scrolling

### DIFF
--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -22,7 +22,7 @@ const experienceBlocks = [
 
 const ExperienceSection = () => {
   return (
-    <section className="experience" id="experience">
+    <section className="experience">
       <motion.div
         className="experience__feature"
         initial={{ opacity: 0, y: 40 }}

--- a/src/components/FullPageScroller.tsx
+++ b/src/components/FullPageScroller.tsx
@@ -319,6 +319,7 @@ const FullPageScroller = ({ sections }: FullPageScrollerProps) => {
         return (
           <section
             key={section.id}
+            id={section.id}
             className={sectionClassNames}
             aria-hidden={!isActive}
             aria-label={section.label}

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -42,7 +42,7 @@ const newsItems = [
 
 const GallerySection = () => {
   return (
-    <section className="gallery" id="gallery">
+    <section className="gallery">
       <div className="gallery__hero">
         <div className="gallery__hero-content">
           <p className="section-badge">공간 & 센터 미리보기</p>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -15,7 +15,7 @@ const floatingVariants = {
 
 const HeroSection = () => {
   return (
-    <header className="hero" id="home">
+    <header className="hero">
       <div className="hero__visual">
         <img
           src="https://24onamc.com/theme/kt001a/img/main_visual01.jpg"

--- a/src/components/InquirySection.tsx
+++ b/src/components/InquirySection.tsx
@@ -48,7 +48,7 @@ const InquirySection = () => {
   };
 
   return (
-    <section className="inquiry" id="inquiry">
+    <section className="inquiry">
       <div className="section-heading">
         <p className="section-badge">디지털 문의 시스템</p>
         <h2>우리 아이에게 꼭 맞는 상담을 예약해보세요</h2>

--- a/src/components/MapSection.tsx
+++ b/src/components/MapSection.tsx
@@ -75,7 +75,7 @@ const MapSection = () => {
   }, [isLoaded]);
 
   return (
-    <section className="map" id="map">
+    <section className="map">
       <div className="section-heading">
         <p className="section-badge">찾아오시는 길</p>
         <h2>언제든 부담 없이 방문하세요</h2>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -27,7 +27,7 @@ const specialtyList = [
 
 const ServicesSection = () => {
   return (
-    <section className="services" id="services">
+    <section className="services">
       <div className="services__intro">
         <div className="services__copy">
           <p className="section-badge">서울 펫 클리닉 센터 진료 안내</p>


### PR DESCRIPTION
## Summary
- expose stable ids on the full-page scroller wrapper sections so hash updates point to them
- remove duplicate ids from section content to avoid native anchor jumps that caused the viewport to scroll away

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da2fb357e8832d90fc28be0b0bced0