### PR TITLE
Fix active section positioning in full page scroller

### DIFF
--- a/src/components/FullPageScroller.tsx
+++ b/src/components/FullPageScroller.tsx
@@ -302,7 +302,8 @@ const FullPageScroller = ({ sections }: FullPageScrollerProps) => {
       {sections.map((section, index) => {
         const isActive = index === activeIndex;
         const isPrevSection = index === prevIndex;
-        const relativePosition = index < activeIndex ? 'is-above' : 'is-below';
+        const relativePosition =
+          index === activeIndex ? '' : index < activeIndex ? 'is-above' : 'is-below';
 
         const sectionClassNames = [
           'fp-section',


### PR DESCRIPTION
## Summary
- prevent the active section from receiving positional classes that shift it off-screen
- ensure full page scroller keeps the current view visible when navigating between sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da366db170832db96e5f7b52666c3e