### PR TITLE
Adjust section layouts for responsive viewport heights

### DIFF
--- a/src/styles/experience.css
+++ b/src/styles/experience.css
@@ -1,8 +1,8 @@
 .experience {
-  padding: 6rem 2rem;
+  padding: clamp(3.6rem, 9vh, 6rem) clamp(1.6rem, 4vw, 2.2rem);
   background: radial-gradient(circle at 20% 20%, rgba(79, 93, 140, 0.08), transparent 65%);
   display: grid;
-  gap: 3.5rem;
+  gap: clamp(2.2rem, 6vh, 3.5rem);
 }
 
 .experience__feature {
@@ -11,7 +11,7 @@
   margin: 0 auto;
   border-radius: 36px;
   overflow: hidden;
-  min-height: 360px;
+  min-height: clamp(280px, 44vh, 360px);
   background: url('https://24onamc.com/theme/kt001a/img/sur1.jpg') center/cover no-repeat;
   box-shadow: 0 32px 70px rgba(31, 39, 67, 0.28);
 }
@@ -25,7 +25,7 @@
 .experience__feature-inner {
   position: relative;
   z-index: 2;
-  padding: 3.6rem 3.8rem;
+  padding: clamp(2.4rem, 6vh, 3.6rem) clamp(2.4rem, 5vw, 3.8rem);
   color: #fff;
   max-width: 640px;
 }
@@ -80,8 +80,8 @@
   max-width: 1200px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.4rem, 3.6vh, 2rem);
 }
 
 .experience__block {
@@ -94,7 +94,7 @@
 }
 
 .experience__block-image {
-  height: 220px;
+  height: clamp(180px, 32vh, 220px);
   background-size: cover;
   background-position: center;
 }
@@ -125,10 +125,31 @@
 
 @media (max-width: 640px) {
   .experience {
-    padding: 4.5rem 1.5rem;
+    padding: clamp(2.8rem, 8vh, 4.5rem) 1.5rem;
   }
 
   .experience__feature-inner {
-    padding: 2.4rem;
+    padding: clamp(2rem, 6vh, 2.4rem);
+  }
+}
+
+@media (max-height: 820px) {
+  .experience {
+    padding: clamp(2.6rem, 7vh, 4.2rem) clamp(1.4rem, 4vw, 2rem);
+    gap: clamp(1.8rem, 5vh, 2.8rem);
+  }
+
+  .experience__feature-inner p {
+    margin-bottom: clamp(1.4rem, 4vh, 2rem);
+  }
+}
+
+@media (max-height: 700px) {
+  .experience__feature-inner {
+    padding: clamp(1.8rem, 5vh, 2.4rem);
+  }
+
+  .experience__blocks {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 }

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -1,9 +1,9 @@
 .footer {
   margin: 0 auto;
   max-width: 1200px;
-  padding: 4rem 2rem 3rem;
+  padding: clamp(2.4rem, 6vh, 4rem) clamp(1.6rem, 4vw, 2rem) clamp(2rem, 5vh, 3rem);
   display: grid;
-  gap: 1.4rem;
+  gap: clamp(1rem, 3vh, 1.4rem);
   text-align: center;
   color: var(--color-muted);
 }
@@ -34,6 +34,12 @@
 
 @media (max-width: 768px) {
   .footer {
-    padding: 3rem 1.5rem 2.5rem;
+    padding: clamp(2rem, 6vh, 3rem) 1.5rem clamp(1.8rem, 5vh, 2.5rem);
+  }
+}
+
+@media (max-height: 700px) {
+  .footer {
+    padding-bottom: clamp(1.4rem, 4vh, 2rem);
   }
 }

--- a/src/styles/fullPageScroller.css
+++ b/src/styles/fullPageScroller.css
@@ -11,7 +11,7 @@
   display: flex;
   align-items: stretch;
   justify-content: center;
-  padding: clamp(2.4rem, 6vw, 4.6rem) clamp(1.6rem, 5vw, 4rem);
+  padding: clamp(1.8rem, 5vh, 4.2rem) clamp(1.4rem, 5vw, 4rem);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(238, 243, 255, 0.9));
   transform: translateY(120%);
   opacity: 0;
@@ -125,12 +125,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: calc(100vh - clamp(4.8rem, 12vw, 7.2rem));
+  min-height: calc(100vh - clamp(4rem, 12vh, 6.4rem));
 }
 
 .fp-section-content {
   width: min(1280px, 100%);
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(1.8rem, 5vh, 3rem);
 }
 
 .fp-progress {
@@ -177,7 +181,7 @@
 
 @media (max-width: 900px) {
   .fp-section {
-    padding: clamp(2rem, 8vw, 3.2rem) clamp(1.2rem, 6vw, 2.4rem);
+    padding: clamp(1.8rem, 7vh, 3.2rem) clamp(1.2rem, 6vw, 2.4rem);
   }
 
   .fp-progress {
@@ -187,11 +191,11 @@
 
 @media (max-width: 640px) {
   .fp-section {
-    padding: clamp(1.5rem, 8vw, 2.4rem);
+    padding: clamp(1.4rem, 7vh, 2.4rem);
   }
 
   .fp-section-inner {
-    min-height: calc(100vh - clamp(3.6rem, 16vw, 5.4rem));
+    min-height: calc(100vh - clamp(3rem, 14vh, 4.8rem));
   }
 
   .fp-progress {
@@ -220,5 +224,31 @@
 
   .fp-progress[data-orientation='horizontal'] .fp-progress-track {
     background: rgba(27, 38, 80, 0.2);
+  }
+}
+
+@media (max-height: 820px) {
+  .fp-section {
+    padding: clamp(1.6rem, 6vh, 2.8rem) clamp(1.2rem, 4vw, 2.4rem);
+  }
+
+  .fp-section-inner {
+    min-height: calc(100vh - clamp(3.2rem, 11vh, 4.8rem));
+  }
+
+  .fp-progress {
+    top: clamp(46%, 50vh, 54%);
+  }
+}
+
+@media (max-height: 700px) {
+  .fp-section-content {
+    gap: clamp(1.2rem, 4vh, 2rem);
+  }
+
+  .fp-progress {
+    top: auto;
+    bottom: clamp(1.8rem, 6vh, 2.4rem);
+    transform: none;
   }
 }

--- a/src/styles/gallery.css
+++ b/src/styles/gallery.css
@@ -1,8 +1,8 @@
 .gallery {
-  padding: 6rem 2rem;
+  padding: clamp(3.6rem, 9vh, 6rem) clamp(1.6rem, 4vw, 2.2rem);
   background: linear-gradient(180deg, rgba(101, 185, 182, 0.08), rgba(255, 255, 255, 0.8));
   display: grid;
-  gap: 4.5rem;
+  gap: clamp(2.4rem, 6vh, 4.2rem);
 }
 
 .gallery__hero {
@@ -10,7 +10,7 @@
   margin: 0 auto;
   display: grid;
   grid-template-columns: minmax(0, 0.85fr) minmax(0, 1fr);
-  gap: 2.8rem;
+  gap: clamp(1.8rem, 5vw, 2.8rem);
   align-items: center;
 }
 
@@ -27,25 +27,25 @@
 
 .gallery__slider {
   display: grid;
-  gap: 1.4rem;
+  gap: clamp(1rem, 3vh, 1.4rem);
 }
 
 .gallery__slide {
   display: grid;
   grid-template-columns: 200px 1fr;
-  gap: 1.6rem;
+  gap: clamp(1.1rem, 3vw, 1.6rem);
   background: #fff;
   border-radius: 26px;
   overflow: hidden;
   box-shadow: var(--shadow-soft);
-  padding: 1.2rem;
+  padding: clamp(1rem, 2.4vw, 1.2rem);
 }
 
 .gallery__slide-image {
   border-radius: 22px;
   background-size: cover;
   background-position: center;
-  min-height: 160px;
+  min-height: clamp(140px, 28vh, 180px);
 }
 
 .gallery__slide figcaption {
@@ -71,7 +71,7 @@
   margin: 0 auto;
   background: linear-gradient(120deg, rgba(79, 93, 140, 0.92), rgba(101, 185, 182, 0.75));
   border-radius: 32px;
-  padding: 3.2rem 3rem;
+  padding: clamp(2.4rem, 6vh, 3.2rem) clamp(2.2rem, 5vw, 3rem);
   color: #fff;
   box-shadow: 0 30px 65px rgba(31, 39, 67, 0.3);
 }
@@ -94,17 +94,17 @@
 
 .gallery__news-list {
   display: grid;
-  gap: 1.6rem;
+  gap: clamp(1.1rem, 3vh, 1.6rem);
 }
 
 .gallery__news-item {
   display: grid;
   grid-template-columns: 120px 1fr;
-  gap: 1.4rem;
+  gap: clamp(1rem, 3vw, 1.4rem);
   align-items: center;
   background: rgba(255, 255, 255, 0.1);
   border-radius: 22px;
-  padding: 1rem 1.2rem;
+  padding: clamp(0.85rem, 2.2vw, 1.2rem);
   transition: background 0.3s ease;
 }
 
@@ -151,7 +151,7 @@
 
 @media (max-width: 720px) {
   .gallery {
-    padding: 4.5rem 1.5rem;
+    padding: clamp(2.8rem, 8vh, 4.5rem) 1.5rem;
   }
 
   .gallery__slide {
@@ -159,7 +159,7 @@
   }
 
   .gallery__news {
-    padding: 2.4rem;
+    padding: clamp(2rem, 6vh, 2.4rem);
   }
 
   .gallery__news-item {
@@ -168,5 +168,30 @@
 
   .gallery__news-image {
     padding-top: 60%;
+  }
+}
+
+@media (max-height: 820px) {
+  .gallery {
+    padding: clamp(2.6rem, 7vh, 4.2rem) clamp(1.4rem, 4vw, 2rem);
+    gap: clamp(1.8rem, 5vh, 3rem);
+  }
+
+  .gallery__hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-height: 700px) {
+  .gallery__slide {
+    grid-template-columns: 1fr;
+  }
+
+  .gallery__news {
+    padding: clamp(1.8rem, 5vh, 2.2rem);
+  }
+
+  .gallery__news-item {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -2,18 +2,19 @@
   position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
-  align-items: stretch;
-  gap: 3rem;
+  align-items: center;
+  gap: clamp(2rem, 6vw, 3rem);
   max-width: 1200px;
   margin: 0 auto;
-  padding: 7rem 2.5rem 5rem;
+  padding: clamp(3rem, 8vh, 5.8rem) clamp(1.8rem, 4vw, 2.8rem) clamp(2.6rem, 7vh, 4.8rem);
+  min-height: min(94vh, 880px);
 }
 
 .hero__visual {
   position: relative;
   border-radius: 40px;
   overflow: hidden;
-  min-height: 620px;
+  min-height: clamp(360px, 52vh, 620px);
   box-shadow: 0 30px 65px rgba(31, 39, 67, 0.32);
 }
 
@@ -65,6 +66,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: clamp(1.4rem, 4vh, 2rem);
 }
 
 .hero__badge {
@@ -81,22 +83,22 @@
 }
 
 .hero__title {
-  font-size: clamp(3rem, 4vw, 4.8rem);
-  margin: 1.8rem 0 1.2rem;
+  font-size: clamp(2.6rem, 4.4vw, 4.6rem);
+  margin: clamp(1.2rem, 3vh, 1.8rem) 0 clamp(0.9rem, 2.6vh, 1.2rem);
   font-weight: 800;
   line-height: 1.12;
   color: var(--color-dark);
 }
 
 .hero__subtitle {
-  font-size: 1.15rem;
+  font-size: clamp(1rem, 1.6vw, 1.15rem);
   color: var(--color-muted);
   max-width: 520px;
   line-height: 1.8;
 }
 
 .hero__features {
-  margin: 2.4rem 0 2.8rem;
+  margin: clamp(1.4rem, 4vh, 2.2rem) 0 clamp(1.6rem, 4.6vh, 2.8rem);
   padding: 0;
   list-style: none;
   display: grid;
@@ -159,9 +161,9 @@
 
 .hero__pets {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 1rem;
-  margin-top: 3.4rem;
+  margin-top: clamp(2rem, 5vh, 3.2rem);
 }
 
 .hero__pet {
@@ -179,11 +181,12 @@
 @media (max-width: 1100px) {
   .hero {
     grid-template-columns: 1fr;
-    padding: 6rem 2rem 4rem;
+    padding: clamp(2.6rem, 7vh, 4.6rem) clamp(1.6rem, 4vw, 2.4rem);
   }
 
   .hero__visual {
-    min-height: 420px;
+    min-height: clamp(320px, 50vh, 520px);
+    order: 2;
   }
 
   .hero__content {
@@ -191,9 +194,50 @@
   }
 }
 
+@media (max-height: 820px) {
+  .hero {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    padding: clamp(2.4rem, 6vh, 4.2rem) clamp(1.6rem, 4vw, 2.4rem);
+    gap: clamp(1.6rem, 6vh, 2.4rem);
+  }
+
+  .hero__visual {
+    order: 2;
+    min-height: clamp(280px, 48vh, 420px);
+  }
+
+  .hero__content {
+    order: 1;
+    gap: clamp(1.1rem, 3vh, 1.6rem);
+  }
+
+  .hero__pets {
+    margin-top: clamp(1.6rem, 4vh, 2.4rem);
+  }
+}
+
+@media (max-height: 700px) {
+  .hero {
+    padding: clamp(2rem, 6vh, 3.6rem) clamp(1.4rem, 4vw, 2rem);
+  }
+
+  .hero__title {
+    font-size: clamp(2.3rem, 5.6vw, 3.4rem);
+  }
+
+  .hero__subtitle {
+    font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  }
+
+  .hero__pets {
+    display: none;
+  }
+}
+
 @media (max-width: 640px) {
   .hero {
-    padding: 5rem 1.6rem 3.5rem;
+    padding: clamp(2.2rem, 7vh, 3.8rem) clamp(1.3rem, 5vw, 1.8rem);
   }
 
   .hero__features {
@@ -202,6 +246,10 @@
 
   .hero__features li {
     padding: 0.7rem 1.2rem;
+  }
+
+  .hero__visual {
+    min-height: clamp(260px, 52vh, 420px);
   }
 
   .hero__pets {

--- a/src/styles/inquiry.css
+++ b/src/styles/inquiry.css
@@ -1,6 +1,6 @@
 
 .inquiry {
-  padding: 6rem 2rem;
+  padding: clamp(3.6rem, 9vh, 6rem) clamp(1.6rem, 4vw, 2.2rem);
   background: radial-gradient(circle at 80% 20%, rgba(101, 185, 182, 0.18), transparent 60%);
 }
 
@@ -9,11 +9,11 @@
   margin: 0 auto;
   background: #fff;
   border-radius: 32px;
-  padding: 3rem;
+  padding: clamp(2.4rem, 6vh, 3rem);
   box-shadow: var(--shadow-soft);
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.8rem 1.6rem;
+  gap: clamp(1.2rem, 3vh, 1.8rem) clamp(1.1rem, 2.8vw, 1.6rem);
 }
 
 .form-group {
@@ -89,12 +89,12 @@
 
 @media (max-width: 768px) {
   .inquiry {
-    padding: 4.5rem 1.5rem;
+    padding: clamp(2.8rem, 8vh, 4.5rem) 1.5rem;
   }
 
   .inquiry__form {
     grid-template-columns: 1fr;
-    padding: 2.4rem;
+    padding: clamp(2rem, 6vh, 2.4rem);
   }
 
   .form-group--full,
@@ -106,6 +106,22 @@
 
 @media (max-width: 520px) {
   .inquiry__form {
-    padding: 2rem;
+    padding: clamp(1.6rem, 6vh, 2rem);
+  }
+}
+
+@media (max-height: 820px) {
+  .inquiry {
+    padding: clamp(2.6rem, 7vh, 4.2rem) clamp(1.4rem, 4vw, 2rem);
+  }
+
+  .inquiry__form {
+    gap: clamp(1rem, 3vh, 1.4rem) 1.4rem;
+  }
+}
+
+@media (max-height: 700px) {
+  .inquiry__form {
+    padding: clamp(1.8rem, 5vh, 2.2rem);
   }
 }

--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -1,19 +1,19 @@
 .map {
-  padding: 6rem 2rem;
+  padding: clamp(3.6rem, 9vh, 6rem) clamp(1.6rem, 4vw, 2.2rem);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.75), rgba(101, 185, 182, 0.08));
 }
 
 .map__container {
   display: grid;
   grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
-  gap: 2rem;
+  gap: clamp(1.4rem, 3.6vw, 2rem);
   max-width: 1200px;
   margin: 0 auto;
   align-items: stretch;
 }
 
 .map__canvas {
-  min-height: 420px;
+  min-height: clamp(320px, 48vh, 420px);
   border-radius: 32px;
   overflow: hidden;
   box-shadow: 0 30px 65px rgba(31, 39, 67, 0.18);
@@ -22,11 +22,11 @@
 .map__details {
   background: #fff;
   border-radius: 32px;
-  padding: 2.6rem;
+  padding: clamp(2rem, 5vh, 2.6rem);
   box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: clamp(0.9rem, 2.4vh, 1.2rem);
 }
 
 .map__details h3 {
@@ -82,12 +82,28 @@
   }
 
   .map__canvas {
-    min-height: 360px;
+    min-height: clamp(280px, 44vh, 360px);
   }
 }
 
 @media (max-width: 768px) {
   .map {
-    padding: 4.5rem 1.5rem;
+    padding: clamp(2.8rem, 8vh, 4.5rem) 1.5rem;
+  }
+}
+
+@media (max-height: 820px) {
+  .map {
+    padding: clamp(2.6rem, 7vh, 4.2rem) clamp(1.4rem, 4vw, 2rem);
+  }
+
+  .map__container {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-height: 700px) {
+  .map__details {
+    padding: clamp(1.6rem, 5vh, 2rem);
   }
 }

--- a/src/styles/services.css
+++ b/src/styles/services.css
@@ -1,14 +1,14 @@
 .services {
-  padding: 6rem 2rem;
+  padding: clamp(3.6rem, 9vh, 6rem) clamp(1.6rem, 4vw, 2.2rem);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.6), rgba(101, 185, 182, 0.05));
 }
 
 .services__intro {
   max-width: 1100px;
-  margin: 0 auto 4rem;
+  margin: 0 auto clamp(2.4rem, 6vh, 3.6rem);
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
-  gap: 2.5rem;
+  gap: clamp(1.8rem, 5vw, 2.5rem);
   align-items: center;
 }
 
@@ -75,18 +75,18 @@
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.8rem;
+  gap: clamp(1.2rem, 3vw, 1.8rem);
 }
 
 .services__card {
   position: relative;
   background: #fff;
   border-radius: 28px;
-  padding: 2.6rem 2.4rem;
+  padding: clamp(2rem, 5vh, 2.6rem) clamp(1.8rem, 4vw, 2.4rem);
   box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: clamp(1.1rem, 3vh, 1.4rem);
   overflow: hidden;
   transition: transform 0.35s ease, box-shadow 0.35s ease;
 }
@@ -142,12 +142,37 @@
 
   .services__photo {
     order: 1;
-    min-height: 320px;
+    min-height: clamp(260px, 48vh, 360px);
+  }
+}
+
+@media (max-height: 820px) {
+  .services {
+    padding: clamp(2.8rem, 7vh, 4.2rem) clamp(1.4rem, 4vw, 2rem);
+  }
+
+  .services__intro {
+    grid-template-columns: 1fr;
+    gap: clamp(1.4rem, 4vh, 2rem);
+  }
+
+  .services__photo {
+    min-height: clamp(240px, 42vh, 340px);
+  }
+}
+
+@media (max-height: 700px) {
+  .services__grid {
+    gap: 1.2rem;
+  }
+
+  .services__card {
+    padding: 1.8rem 1.6rem;
   }
 }
 
 @media (max-width: 640px) {
   .services {
-    padding: 4rem 1.5rem;
+    padding: clamp(2.6rem, 8vh, 4rem) 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- refine the full-page scroller padding and content spacing so each section adapts to shorter viewports
- tighten hero, services, experience, gallery, inquiry, map, and footer styles with clamp-based sizing and height breakpoints
- ensure section imagery and grids collapse gracefully on compact desktop and mobile screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da3875c094832d86af6fb5e3349483