### PR TITLE
Add layered background fade during section transitions

### DIFF
--- a/src/components/FullPageScroller.tsx
+++ b/src/components/FullPageScroller.tsx
@@ -335,8 +335,47 @@ const FullPageScroller = ({ sections }: FullPageScrollerProps) => {
   const progressStyle =
     orientation === 'horizontal' ? ({ ['--fp-progress' as const]: `${progressValue}%` } as CSSProperties) : undefined;
 
+  const backgroundClassNames = useMemo(
+    () =>
+      sections.map((section) => {
+        const className = section.className ?? '';
+        return className
+          .split(/\s+/)
+          .filter((token) => token && token.startsWith('section-bg-'))
+          .join(' ');
+      }),
+    [sections],
+  );
+
   return (
     <div className="fullpage-container" ref={containerRef}>
+      <div className="fp-backgrounds" aria-hidden="true">
+        {sections.map((section, index) => {
+          const isActiveBackground = index === activeIndex;
+          const isPrevBackground = index === prevIndex;
+          const backgroundClassName = [
+            'fp-background-layer',
+            backgroundClassNames[index],
+            isActiveBackground ? 'is-active' : '',
+            isPrevBackground ? 'is-prev' : '',
+            isActiveBackground && isAnimating
+              ? direction === 'down'
+                ? 'entering-down'
+                : 'entering-up'
+              : '',
+            isPrevBackground && isAnimating
+              ? direction === 'down'
+                ? 'leaving-down'
+                : 'leaving-up'
+              : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+
+          return <div key={`${section.id}-background`} className={backgroundClassName} />;
+        })}
+      </div>
+
       {sections.map((section, index) => {
         const isActive = index === activeIndex;
         const isPrevSection = index === prevIndex;

--- a/src/styles/fullPageScroller.css
+++ b/src/styles/fullPageScroller.css
@@ -24,13 +24,7 @@
   align-items: stretch;
   justify-content: center;
   padding: clamp(1.8rem, 4.8vh, 3.8rem) clamp(1.4rem, 4.4vw, 3.6rem);
-  background: var(
-    --fp-section-background,
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(238, 243, 255, 0.9))
-  );
-  background-size: cover, cover;
-  background-position: center, center;
-  background-repeat: no-repeat, no-repeat;
+  background: transparent;
   transform: translateY(120%);
   opacity: 0;
   pointer-events: none;
@@ -38,47 +32,104 @@
   z-index: 1;
 }
 
+.fp-backgrounds {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.fp-background-layer {
+  position: absolute;
+  inset: 0;
+  background: var(
+    --fp-section-background,
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(238, 243, 255, 0.9))
+  );
+  background-size: cover, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+  opacity: 0;
+  transform: scale(1.045);
+  --fp-bg-opacity-duration: 0.55s;
+  --fp-bg-transform-duration: 1.2s;
+  transition:
+    opacity var(--fp-bg-opacity-duration) cubic-bezier(0.22, 0.75, 0.28, 1),
+    transform var(--fp-bg-transform-duration) cubic-bezier(0.16, 0.8, 0.24, 1);
+}
+
+.fp-background-layer.is-active {
+  opacity: 1;
+  transform: scale(1);
+  z-index: 2;
+}
+
+.fp-background-layer.is-prev {
+  --fp-bg-opacity-duration: 0.92s;
+  transform: scale(1.02);
+  z-index: 1;
+}
+
+.fp-background-layer.entering-down,
+.fp-background-layer.entering-up {
+  --fp-bg-transform-duration: 1.1s;
+}
+
+.fp-background-layer.leaving-down,
+.fp-background-layer.leaving-up {
+  --fp-bg-transform-duration: 1.1s;
+  --fp-bg-opacity-duration: 0.92s;
+}
+
 .fp-section.tone-dark {
   color: rgba(236, 240, 255, 0.95);
 }
 
-.fp-section.section-bg-1 {
+.fp-section.section-bg-1,
+.fp-background-layer.section-bg-1 {
   --fp-section-background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(101, 185, 182, 0.32)),
     var(--fp-section-bg-image-1);
 }
 
-.fp-section.section-bg-2 {
+.fp-section.section-bg-2,
+.fp-background-layer.section-bg-2 {
   --fp-section-background:
     linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(94, 179, 175, 0.28)),
     var(--fp-section-bg-image-2);
 }
 
-.fp-section.section-bg-3 {
+.fp-section.section-bg-3,
+.fp-background-layer.section-bg-3 {
   --fp-section-background:
     linear-gradient(150deg, rgba(18, 30, 72, 0.82), rgba(33, 56, 112, 0.76)),
     var(--fp-section-bg-image-3);
 }
 
-.fp-section.section-bg-4 {
+.fp-section.section-bg-4,
+.fp-background-layer.section-bg-4 {
   --fp-section-background:
     linear-gradient(150deg, rgba(255, 255, 255, 0.9), rgba(86, 112, 170, 0.3)),
     var(--fp-section-bg-image-4);
 }
 
-.fp-section.section-bg-5 {
+.fp-section.section-bg-5,
+.fp-background-layer.section-bg-5 {
   --fp-section-background:
     linear-gradient(165deg, rgba(236, 248, 255, 0.85), rgba(73, 136, 152, 0.35)),
     var(--fp-section-bg-image-5);
 }
 
-.fp-section.section-bg-6 {
+.fp-section.section-bg-6,
+.fp-background-layer.section-bg-6 {
   --fp-section-background:
     linear-gradient(155deg, rgba(255, 255, 255, 0.88), rgba(79, 93, 140, 0.34)),
     var(--fp-section-bg-image-6);
 }
 
-.fp-section.section-bg-7 {
+.fp-section.section-bg-7,
+.fp-background-layer.section-bg-7 {
   --fp-section-background:
     linear-gradient(165deg, rgba(249, 252, 255, 0.9), rgba(101, 185, 182, 0.26)),
     var(--fp-section-bg-image-7);


### PR DESCRIPTION
## Summary
- add dedicated background layers that fade alongside section transitions so the imagery is visible from the start of the scroll animation
- update the full-page scroller to compute background classes and render synchronized background elements for each section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da4c609c5c832d92553966098bc0a7