### PR TITLE
Fix z-index layering for full page sections

### DIFF
--- a/src/components/FullPageScroller.tsx
+++ b/src/components/FullPageScroller.tsx
@@ -375,7 +375,7 @@ const FullPageScroller = ({ sections }: FullPageScrollerProps) => {
             .filter(Boolean)
             .join(' ');
 
-          const backgroundBaseLayer = index + 1;
+          const backgroundBaseLayer = totalSections - index;
           const backgroundHighlightOffset = totalSections + 1;
           let backgroundZIndex = backgroundBaseLayer;
 
@@ -417,7 +417,7 @@ const FullPageScroller = ({ sections }: FullPageScrollerProps) => {
           .join(' ');
 
         const sectionBaseOffset = totalSections * 10;
-        const sectionBaseLayer = sectionBaseOffset + index + 1;
+        const sectionBaseLayer = sectionBaseOffset + (totalSections - index);
         const sectionHighlightOffset = totalSections + 1;
         let sectionZIndex = sectionBaseLayer;
 


### PR DESCRIPTION
## Summary
- reverse the base z-index stacking order for fullpage backgrounds and sections to match their visual order
- ensure the active section still sits on top without lower sections bleeding through during transitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db462b1558832d9b85c1d4a15906ae