### PR TITLE
Refine hero layout and polish section content

### DIFF
--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -3,20 +3,20 @@ import '../styles/experience.css';
 
 const experienceBlocks = [
   {
-    title: '영상진단센터',
+    title: '영상진단 존',
     description:
-      '128채널 CT와 최신 DR X-ray, 초음파 장비를 갖춘 영상진단센터에서 빠르고 정확한 판독을 제공합니다.',
-    image: 'https://24onamc.com/theme/kt001a/img/sur2.jpg'
+      '128채널 CT, 고해상도 초음파, 디지털 X-ray를 갖춘 공간에서 케이스별 맞춤 프로토콜로 판독합니다.',
+    image: 'https://images.unsplash.com/photo-1550583724-b2692b85b150?auto=format&fit=crop&w=1200&q=80'
   },
   {
-    title: '스페셜티 협진',
-    description: '심장·신경·재활·피부 등 전문 의료진이 24ON 네트워크와 함께 협력 진료를 진행합니다.',
-    image: 'https://24onamc.com/theme/kt001a/img/about3.jpg'
+    title: '스페셜티 협진 스테이션',
+    description: '심장 · 신경 · 재활 전문 의료진이 동일한 EMR을 공유하며 실시간으로 협진합니다.',
+    image: 'https://images.unsplash.com/photo-1580281657521-3898e9480a06?auto=format&fit=crop&w=1200&q=80'
   },
   {
     title: '회복 & 웰니스 라운지',
-    description: '프라이빗 입원실과 보호자 라운지, 감성 케어 프로그램으로 안심하고 회복할 수 있는 환경을 제공합니다.',
-    image: 'https://24onamc.com/theme/kt001a/img/about1.jpg'
+    description: '프라이빗 입원실, 보호자 라운지, 아로마 케어 프로그램으로 회복 시간을 편안하게 채웁니다.',
+    image: 'https://images.unsplash.com/photo-1615461066841-1eef8e612955?auto=format&fit=crop&w=1200&q=80'
   }
 ];
 
@@ -32,24 +32,24 @@ const ExperienceSection = () => {
       >
         <div className="experience__feature-overlay" />
         <div className="experience__feature-inner">
-          <p className="experience__badge">첨단 영상진단센터 안내</p>
-          <h2>첨단 영상장비와 숙련된 전공의 팀</h2>
+          <p className="experience__badge">센터 경험 미리보기</p>
+          <h2>하루 종일 이어지는 몰입형 의료 서비스</h2>
           <p>
-            CT, 초음파, X-ray, C-Arm 등 최신 영상장비를 완비한 진단센터에서 정확한 진단과 빠른 치료 계획을
-            세우세요. 영상의학과 전공의가 24시간 상주하며 협진 시스템을 가동합니다.
+            진료, 검사, 수술, 회복이 하나의 동선 안에서 매끄럽게 진행됩니다. 전문과 의료진과 케어 매니저가
+            팀을 이루어 보호자님과 반려동물이 머무는 모든 순간을 세심하게 살핍니다.
           </p>
           <div className="experience__stats">
             <div>
               <strong>128ch</strong>
-              <span>멀티 슬라이스 CT</span>
+              <span>프리미엄 영상 진단</span>
             </div>
             <div>
               <strong>24h</strong>
-              <span>상시 판독 지원</span>
+              <span>전담 의료진 상주</span>
             </div>
             <div>
-              <strong>5Team</strong>
-              <span>스페셜티 협진</span>
+              <strong>5 Team</strong>
+              <span>스페셜티 협진 라인업</span>
             </div>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,11 +9,11 @@ const Footer = ({ currentYear }: FooterProps) => {
     <footer className="footer">
       <div className="footer__brand">
         <span className="footer__logo">서울 펫 클리닉 센터</span>
-        <p>24ON AMC 협력 프리미엄 동물의료 네트워크</p>
+        <p>젊은 보호자를 위한 24시 프리미엄 동물의료 파트너</p>
       </div>
       <div className="footer__info">
         <p>서울특별시 송파구 위례성대로 14길 24 · 지상 2F</p>
-        <p>대표번호 02-7777-1234 · 24시 응급 라인 010-9876-5432</p>
+        <p>상담 02-7777-1234 · 24시 응급 010-9876-5432</p>
       </div>
       <div className="footer__copyright">
         © {currentYear} Seoul Pet Clinic Center. All rights reserved.

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -3,40 +3,37 @@ import '../styles/gallery.css';
 
 const gallerySlides = [
   {
-    title: '서울 펫 클리닉 센터 투어',
-    description: '감각적인 인테리어와 감성 조명이 어우러진 공간, 프라이빗 라운지를 미리 만나보세요.',
-    image: 'https://24onamc.com/theme/kt001a/img/main_visual02.jpg'
+    title: '로비 & 웰컴 라운지',
+    description: '자연광이 들어오는 로비에서 반려동물과 보호자를 가장 먼저 따뜻하게 맞이합니다.',
+    image: 'https://images.unsplash.com/photo-1610276198568-eb6d0ff53d79?auto=format&fit=crop&w=1200&q=80'
   },
   {
-    title: '스페셜티 수술센터',
-    description: '무균 수술실과 회복실, 집중케어실까지 한 공간에 구성해 안전한 수술 환경을 제공합니다.',
-    image: 'https://24onamc.com/theme/kt001a/img/sur3.jpg'
+    title: '수술 준비 구역',
+    description: '무균 환경으로 설계된 준비실에서 수술 전 체크리스트를 꼼꼼하게 점검합니다.',
+    image: 'https://images.unsplash.com/photo-1576765607924-3ddca5f90ca5?auto=format&fit=crop&w=1200&q=80'
   },
   {
-    title: '힐링 펫 라운지',
-    description: '여성 보호자를 위한 프라이빗 상담존과 향기로운 티 바, 포토 스팟을 준비했습니다.',
-    image: 'https://24onamc.com/theme/kt001a/img/about4.jpg'
+    title: '보호자 케어 라운지',
+    description: '프라이빗 좌석과 향기로운 티 서비스로 케어 중에도 편안한 휴식을 드립니다.',
+    image: 'https://images.unsplash.com/photo-1616628182501-d48e0d3f0c8d?auto=format&fit=crop&w=1200&q=80'
   }
 ];
 
 const newsItems = [
   {
-    title: '[희망이의 치료 여정 2] 불길 속에서 살아난 희망',
-    date: '2025.04.23',
-    image:
-      'https://24onamc.com/data/editor/2504/thumb-f0e895a2f7e9c6967f77b3bb6fae40c5_1745369212_3398_600x.jpg'
+    title: '야간 응급 전담팀 신설 안내',
+    date: '2025.04.27',
+    image: 'https://images.unsplash.com/photo-1550831107-1553da8c8464?auto=format&fit=crop&w=800&q=80'
   },
   {
-    title: '[희망이의 치료 여정 1] 산불 현장에서 구조된 작은 생명',
-    date: '2025.04.16',
-    image:
-      'https://24onamc.com/data/editor/2504/thumb-87f2172353105c219a1d2b77a1c69f27_1744766597_1599_600x.jpg'
+    title: '보호자 케어 라운지 리뉴얼 오픈',
+    date: '2025.04.12',
+    image: 'https://images.unsplash.com/photo-1526403226667-4aa07b0604ef?auto=format&fit=crop&w=800&q=80'
   },
   {
-    title: '첨단 영상진단센터 CT 장비 업그레이드 안내',
-    date: '2025.03.28',
-    image:
-      'https://24onamc.com/data/editor/2503/thumb-521bcfddcd7f1a71296eb4c11b0e1b7e_1743279352_9973_600x.jpg'
+    title: '심장 재활 프로그램 런칭',
+    date: '2025.03.30',
+    image: 'https://images.unsplash.com/photo-1597645587822-e99fa5d45d25?auto=format&fit=crop&w=800&q=80'
   }
 ];
 
@@ -45,11 +42,11 @@ const GallerySection = () => {
     <section className="gallery">
       <div className="gallery__hero">
         <div className="gallery__hero-content">
-          <p className="section-badge">공간 & 센터 미리보기</p>
-          <h2>서울 펫 클리닉 센터의 특별한 하루</h2>
+          <p className="section-badge">센터 공간 스케치</p>
+          <h2>감각적인 휴식과 진료가 공존하는 무드</h2>
           <p>
-            24on AMC의 감각적인 공간 구성과 전문 진료 동선을 그대로 담았습니다. 젊은 보호자들이 선호하는
-            파스텔 무드, 라탄 포인트, 감성 조명이 어우러져 힐링되는 시간을 선사합니다.
+            반려동물과 보호자가 모두 편안함을 느끼도록 동선을 정리하고, 공간마다 다른 감성을 담았습니다.
+            머무는 동안 자연스럽게 긴장이 풀리는 서울 펫 클리닉 센터의 하루를 살펴보세요.
           </p>
         </div>
         <div className="gallery__slider">
@@ -74,8 +71,8 @@ const GallerySection = () => {
 
       <div className="gallery__news">
         <div className="gallery__news-header">
-          <h3>서울 펫 클리닉 소식</h3>
-          <span>실시간으로 업데이트되는 치료 이야기</span>
+          <h3>센터 뉴스</h3>
+          <span>서울 펫 클리닉 센터의 최신 소식을 만나보세요</span>
         </div>
         <div className="gallery__news-list">
           {newsItems.map((item, index) => (
@@ -91,7 +88,7 @@ const GallerySection = () => {
               <div className="gallery__news-content">
                 <span className="gallery__news-date">{item.date}</span>
                 <h4>{item.title}</h4>
-                <p>서울 펫 클리닉 센터에서 진행 중인 특별한 치료 사례와 감동적인 이야기들을 만나보세요.</p>
+                <p>보호자님께 도움이 될 만한 진료 소식과 센터 업데이트를 정기적으로 전해드립니다.</p>
               </div>
             </motion.article>
           ))}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,127 +1,144 @@
 import { motion } from 'framer-motion';
 import '../styles/hero.css';
 
-const floatingVariants = {
-  initial: { y: 0 },
-  animate: {
-    y: [0, -18, 0],
-    transition: {
-      duration: 5,
-      repeat: Infinity,
-      ease: 'easeInOut'
-    }
-  }
-};
+const heroHighlights = [
+  {
+    title: '24시간 전담 진료',
+    description: '응급, 입원, 야간 협진까지 한 번에 이어지는 원스톱 케어',
+  },
+  {
+    title: '첨단 영상 · 수술 시스템',
+    description: '128ch CT와 무균 수술실, 회복실을 연결한 토탈 진료 인프라',
+  },
+  {
+    title: '라이프스타일 컨시어지',
+    description: '젊은 보호자를 위한 프라이빗 상담존과 감성 라운지 운영',
+  },
+];
+
+const heroFacts = [
+  { label: '진료시간', value: '연중무휴 24h' },
+  { label: '상담 채널', value: '전화 · 카카오톡 · 온라인' },
+  { label: '위치', value: '역삼역 3번 출구 도보 3분' },
+];
 
 const HeroSection = () => {
   return (
     <header className="hero">
-      <div className="hero__visual">
+      <div className="hero__background" aria-hidden>
         <img
-          src="https://24onamc.com/theme/kt001a/img/main_visual01.jpg"
-          alt="따뜻하게 안아주는 수의사와 강아지"
-          className="hero__image"
+          src="https://images.unsplash.com/photo-1558944351-c3a08818bd0c?auto=format&fit=crop&w=1600&q=80"
+          alt="감각적인 동물병원 내부"
           loading="lazy"
         />
-        <div className="hero__overlay" />
-        <motion.div
-          className="hero__floating hero__floating--left"
-          variants={floatingVariants}
-          initial="initial"
-          animate="animate"
-        >
-          <span>24시간 케어</span>
-          <strong>응급 · 입원 시스템</strong>
-        </motion.div>
-        <motion.div
-          className="hero__floating hero__floating--right"
-          variants={floatingVariants}
-          initial="initial"
-          animate="animate"
-        >
-          <span>첨단 영상진단</span>
-          <strong>CT · X-ray · 초음파</strong>
-        </motion.div>
+        <div className="hero__background-overlay" />
       </div>
-      <div className="hero__content">
-        <motion.p
+
+      <div className="hero__inner">
+        <motion.span
           className="hero__badge"
-          initial={{ opacity: 0, y: -16 }}
+          initial={{ opacity: 0, y: -12 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.7 }}
+          transition={{ duration: 0.6 }}
         >
-          서울 펫 클리닉 센터
-        </motion.p>
+          24ON AMC 협력 프리미엄 센터
+        </motion.span>
+
+        <motion.div
+          className="hero__logo"
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+        >
+          <svg viewBox="0 0 64 64" role="img" aria-label="서울 펫 클리닉 로고">
+            <circle cx="32" cy="32" r="30" fill="url(#heroLogoGradient)" />
+            <path
+              d="M32 18c-4.3 0-7.8 3.5-7.8 7.8 0 1.5.4 3 1.2 4.2l6.6 10.5 6.6-10.5c.8-1.2 1.2-2.7 1.2-4.2 0-4.3-3.5-7.8-7.8-7.8zm0 11.4a3.6 3.6 0 1 1 0-7.2 3.6 3.6 0 0 1 0 7.2z"
+              fill="#fff"
+            />
+            <path
+              d="M22.2 35.4c-4.1 0-7.4 3.3-7.4 7.4S18.1 50.2 22.2 50.2c2.4 0 4.5-1.1 5.9-2.8l3.9-5.6-3.9-6c-1.3-2-3.5-3.2-5.9-3.2zM41.8 35.4c-2.4 0-4.6 1.2-5.9 3.2l-3.9 6 3.9 5.6c1.4 1.8 3.5 2.8 5.9 2.8 4.1 0 7.4-3.3 7.4-7.4s-3.3-7.4-7.4-7.4z"
+              fill="#fff"
+              opacity="0.88"
+            />
+            <defs>
+              <linearGradient id="heroLogoGradient" x1="12" y1="12" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+                <stop offset="0%" stopColor="#65b9b6" />
+                <stop offset="100%" stopColor="#4f5d8c" />
+              </linearGradient>
+            </defs>
+          </svg>
+        </motion.div>
+
         <motion.h1
           className="hero__title"
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.1 }}
+          transition={{ duration: 0.7, delay: 0.15 }}
         >
-          젊은 보호자를 위한<br />
-          프리미엄 24시 동물병원
+          서울 펫 클리닉 센터
         </motion.h1>
+
         <motion.p
           className="hero__subtitle"
-          initial={{ opacity: 0, y: 24 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.2 }}
-        >
-          반려가족의 하루에 스며드는 감각적인 공간, 첨단 장비와 숙련된 의료진의 팀 케어로 안심을 전합니다.
-        </motion.p>
-        <motion.ul
-          className="hero__features"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.3 }}
+          transition={{ duration: 0.7, delay: 0.2 }}
         >
-          <li>여의도 · 강남권 10분 내 접근</li>
-          <li>여성 보호자 전용 상담 라운지</li>
-          <li>24on AMC 협력 의료 네트워크</li>
+          프리미엄 24시 동물병원
+        </motion.p>
+
+        <motion.p
+          className="hero__description"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.25 }}
+        >
+          반려가족의 하루에 자연스럽게 스며드는 진료 경험을 디자인했습니다. 감각적인 공간, 첨단 장비,
+          숙련된 의료진이 팀을 이뤄 언제 방문하셔도 동일한 퀄리티의 케어를 제공합니다.
+        </motion.p>
+
+        <motion.ul
+          className="hero__highlights"
+          initial={{ opacity: 0, y: 18 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.35 }}
+        >
+          {heroHighlights.map((highlight) => (
+            <li key={highlight.title}>
+              <h3>{highlight.title}</h3>
+              <p>{highlight.description}</p>
+            </li>
+          ))}
         </motion.ul>
-        <div className="hero__actions">
-          <motion.a
-            href="#inquiry"
-            className="hero__cta"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.98 }}
-          >
-            맞춤 상담 예약하기
-          </motion.a>
-          <motion.a
-            href="#map"
-            className="hero__cta hero__cta--ghost"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.98 }}
-          >
-            오시는 길 보기
-          </motion.a>
-        </div>
+
         <motion.div
-          className="hero__pets"
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.8, delay: 0.4 }}
+          className="hero__actions"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.4 }}
         >
-          <img
-            src="https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=900&q=80"
-            alt="웃는 강아지"
-            className="hero__pet"
-            loading="lazy"
-          />
-          <img
-            src="https://images.unsplash.com/photo-1555685812-4b943f1cb0eb?auto=format&fit=crop&w=900&q=80"
-            alt="포근한 고양이"
-            className="hero__pet"
-            loading="lazy"
-          />
-          <img
-            src="https://images.unsplash.com/photo-1548199973-03cce0bbc87b?auto=format&fit=crop&w=900&q=80"
-            alt="함께 있는 강아지와 고양이"
-            className="hero__pet"
-            loading="lazy"
-          />
+          <a href="#inquiry" className="hero__cta">
+            상담 예약하기
+          </a>
+          <a href="#services" className="hero__cta hero__cta--ghost">
+            센터 프로그램 보기
+          </a>
         </motion.div>
+
+        <motion.dl
+          className="hero__facts"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.45 }}
+        >
+          {heroFacts.map((fact) => (
+            <div key={fact.label} className="hero__fact">
+              <dt>{fact.label}</dt>
+              <dd>{fact.value}</dd>
+            </div>
+          ))}
+        </motion.dl>
       </div>
     </header>
   );

--- a/src/components/InquirySection.tsx
+++ b/src/components/InquirySection.tsx
@@ -35,12 +35,12 @@ const InquirySection = () => {
       });
 
       if (!response.ok) {
-        throw new Error('문의 접수에 실패했어요. 다시 시도해주세요.');
+        throw new Error('문의 접수에 실패했어요. 잠시 후 다시 시도해주세요.');
       }
 
       setValues(initialValues);
       setStatus('success');
-      setFeedback('문의가 접수되었어요! 24시간 이내에 이메일로 연락드릴게요.');
+      setFeedback('문의가 정상적으로 접수되었어요! 24시간 이내에 이메일로 안내드릴게요.');
     } catch (error) {
       setStatus('error');
       setFeedback((error as Error).message);
@@ -50,10 +50,10 @@ const InquirySection = () => {
   return (
     <section className="inquiry">
       <div className="section-heading">
-        <p className="section-badge">디지털 문의 시스템</p>
-        <h2>우리 아이에게 꼭 맞는 상담을 예약해보세요</h2>
+        <p className="section-badge">Smart Inquiry</p>
+        <h2>3분이면 끝나는 스마트 상담 신청</h2>
         <p className="section-description">
-          문의를 남겨주시면 담당 케어 매니저가 라이프스타일에 맞춘 진료 플랜을 제안드립니다.
+          기본 정보를 남겨주시면 케어 매니저가 반려동물의 컨디션과 일정에 맞춘 맞춤 플랜을 제안드려요.
         </p>
       </div>
       <motion.form
@@ -70,7 +70,7 @@ const InquirySection = () => {
             id="name"
             name="name"
             type="text"
-            placeholder="이름을 입력해주세요"
+            placeholder="보호자 성함을 입력해주세요"
             value={values.name}
             onChange={(event) => setValues({ ...values, name: event.target.value })}
             required
@@ -82,7 +82,7 @@ const InquirySection = () => {
             id="email"
             name="email"
             type="email"
-            placeholder="example@email.com"
+            placeholder="연락 가능한 이메일을 입력해주세요"
             value={values.email}
             onChange={(event) => setValues({ ...values, email: event.target.value })}
             required
@@ -110,7 +110,7 @@ const InquirySection = () => {
           <textarea
             id="message"
             name="message"
-            placeholder="반려동물의 컨디션이나 상담을 원하는 내용을 자유롭게 적어주세요"
+            placeholder="반려동물의 컨디션과 상담을 원하는 내용을 자유롭게 적어주세요"
             rows={5}
             value={values.message}
             onChange={(event) => setValues({ ...values, message: event.target.value })}
@@ -124,7 +124,7 @@ const InquirySection = () => {
           whileTap={{ scale: 0.97 }}
           disabled={status === 'loading'}
         >
-          {status === 'loading' ? '전송 중...' : '문의 남기기'}
+          {status === 'loading' ? '전송 중...' : '문의 보내기'}
         </motion.button>
         {status !== 'idle' && (
           <p className={`inquiry__feedback inquiry__feedback--${status}`}>

--- a/src/components/MapSection.tsx
+++ b/src/components/MapSection.tsx
@@ -61,7 +61,7 @@ const MapSection = () => {
       <div class="map-info">
         <h3>서울 펫 클리닉 센터</h3>
         <p>서울특별시 강남구 테헤란로 123</p>
-        <p class="map-info__highlight">영업시간 10:00 - 21:00 (연중무휴)</p>
+        <p class="map-info__highlight">연중무휴 24시간 진료</p>
       </div>
     `;
 
@@ -77,10 +77,11 @@ const MapSection = () => {
   return (
     <section className="map">
       <div className="section-heading">
-        <p className="section-badge">찾아오시는 길</p>
-        <h2>언제든 부담 없이 방문하세요</h2>
+        <p className="section-badge">방문 안내</p>
+        <h2>역삼역에서 가장 가까운 24시 동물병원</h2>
         <p className="section-description">
-          2호선 역삼역 3번 출구 도보 3분. 주차 발렛과 반려동물 픽업 서비스도 준비되어 있어요.
+          2호선 역삼역 3번 출구에서 도보 3분. 지하 주차장 발렛과 반려동물 픽업 서비스를 통해 이동 부담을
+          줄였습니다.
         </p>
       </div>
       <motion.div
@@ -96,11 +97,11 @@ const MapSection = () => {
           <p>서울특별시 강남구 테헤란로 123, 2층</p>
           <ul>
             <li>지하철 2호선 역삼역 3번 출구 도보 3분</li>
-            <li>카페 같은 무드의 라운지와 포토존</li>
-            <li>야간 응급 협력 네트워크 운영</li>
+            <li>지하 주차장 발렛 & 보호자 픽업 서비스</li>
+            <li>야간 응급 전담팀 · 24ON 협력 네트워크</li>
           </ul>
           <a className="map__link" href="tel:0277771234">
-            지금 바로 전화하기 02-7777-1234
+            상담 및 예약 02-7777-1234
           </a>
         </div>
       </motion.div>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -3,78 +3,80 @@ import '../styles/services.css';
 
 const carePrograms = [
   {
-    title: '24시 통합 진료 센터',
-    description: '내과 · 외과 · 치과 · 피부과 전문의가 팀을 이루어 케이스별 맞춤 진료 프로세스를 운영합니다.',
-    accent: '24ON AMC 네트워크 연계'
+    title: '메디컬 코디네이션',
+    description: '진료 전 상담, 검사 설계, 치료 플랜까지 전담 케어 매니저가 전체 과정을 연결합니다.',
+    accent: '전담 케어 매니저 배정',
   },
   {
-    title: '정밀 영상 진단',
-    description: '128ch CT, 디지털 X-ray, 고해상도 초음파 장비로 정확한 진단과 빠른 치료 결정을 돕습니다.',
-    accent: '영상의학과 전공의 상주'
+    title: '프리미엄 영상 진단',
+    description: '128채널 CT와 고해상도 초음파, 디지털 X-ray를 활용해 빠르고 정확한 진단을 제공합니다.',
+    accent: '영상의학 전공의 상주',
   },
   {
-    title: '스마트 케어 라운지',
-    description: '젊은 보호자를 위한 프라이빗 상담실과 감성 라운지를 제공하여 편안한 진료 경험을 선사합니다.',
-    accent: '라이프스타일 맞춤 상담'
-  }
+    title: '스페셜티 수술 & 회복',
+    description: '무균 수술실과 회복 라운지를 연결해 수술 후 케어까지 안전하게 이어집니다.',
+    accent: '24시간 모니터링 시스템',
+  },
 ];
 
 const specialtyList = [
-  '국내 최초 여성 보호자 전용 케어 컨시어지',
-  '심장 · 재활 · 피부 등 분야별 협진 시스템',
-  '24시간 회복실 CCTV & 모바일 모니터링'
+  '야간까지 이어지는 전문과 협진 시스템',
+  '응급 · 입원 · 재활을 아우르는 통합 케어',
+  '보호자 전용 라운지와 프라이빗 상담실 상시 운영',
 ];
 
 const ServicesSection = () => {
   return (
     <section className="services">
-      <div className="services__intro">
-        <div className="services__copy">
-          <p className="section-badge">서울 펫 클리닉 센터 진료 안내</p>
-          <h2>대형 동물의료센터 수준의 토탈 케어</h2>
-          <p>
-            24on AMC가 보유한 첨단 장비와 숙련된 의료진, 그리고 젊은 보호자를 위한 감각적인 서비스
-            플로우를 그대로 담았습니다. 진료 전 상담부터 사후 케어까지 믿고 맡겨주세요.
-          </p>
-          <ul className="services__list">
-            {specialtyList.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-          <motion.a
-            href="#inquiry"
-            className="services__cta"
-            whileHover={{ scale: 1.03 }}
-            whileTap={{ scale: 0.98 }}
-          >
-            진료 문의 남기기
-          </motion.a>
+      <div className="services__frame">
+        <div className="services__intro">
+          <div className="services__copy">
+            <p className="section-badge">Signature Care Program</p>
+            <h2>하루 동선에 맞춘 토탈 진료 루틴</h2>
+            <p>
+              서울 펫 클리닉 센터는 진료, 영상, 수술, 회복이 한 공간에서 이어지도록 설계되었습니다. 첫 상담부터
+              사후 케어까지 끊김 없는 플로우로 보호자님이 안심할 수 있는 진료 경험을 만들어갑니다.
+            </p>
+            <ul className="services__list">
+              {specialtyList.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            <motion.a
+              href="#inquiry"
+              className="services__cta"
+              whileHover={{ scale: 1.03 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              상담 스케줄 남기기
+            </motion.a>
+          </div>
+          <div className="services__photo" aria-hidden>
+            <img
+              src="https://images.unsplash.com/photo-1573497491208-6b1acb260507?auto=format&fit=crop&w=1200&q=80"
+              alt="서울 펫 클리닉 센터 진료 공간"
+              loading="lazy"
+            />
+          </div>
         </div>
-        <div className="services__photo" aria-hidden>
-          <img
-            src="https://24onamc.com/theme/kt001a/img/intro.jpg"
-            alt="서울 펫 클리닉 센터 내부"
-            loading="lazy"
-          />
-        </div>
-      </div>
 
-      <div className="services__grid">
-        {carePrograms.map((service, index) => (
-          <motion.article
-            key={service.title}
-            className="services__card"
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: index * 0.1 }}
-            viewport={{ once: true, amount: 0.4 }}
-          >
-            <span className="services__number">0{index + 1}</span>
-            <h3>{service.title}</h3>
-            <p>{service.description}</p>
-            <span className="services__accent">{service.accent}</span>
-          </motion.article>
-        ))}
+        <div className="services__grid">
+          {carePrograms.map((service, index) => (
+            <motion.article
+              key={service.title}
+              className="services__card"
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: index * 0.1 }}
+              viewport={{ once: true, amount: 0.4 }}
+            >
+              <span className="services__number">0{index + 1}</span>
+              <h3>{service.title}</h3>
+              <p>{service.description}</p>
+              <span className="services__accent">{service.accent}</span>
+            </motion.article>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/styles/experience.css
+++ b/src/styles/experience.css
@@ -14,7 +14,8 @@
   border-radius: 36px;
   overflow: hidden;
   min-height: clamp(280px, 44vh, 360px);
-  background: url('https://24onamc.com/theme/kt001a/img/sur1.jpg') center/cover no-repeat;
+  background: url('https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1600&q=80')
+    center/cover no-repeat;
   box-shadow: 0 32px 70px rgba(31, 39, 67, 0.28);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,3 +32,39 @@ img {
   max-width: 100%;
   display: block;
 }
+
+.section-heading {
+  width: min(100%, 760px);
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(2.2rem, 3vw, 2.8rem);
+  font-weight: 800;
+  color: var(--color-dark);
+}
+
+.section-badge {
+  display: inline-flex;
+  align-self: center;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(79, 93, 140, 0.08);
+  color: var(--color-dark);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-description {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.7;
+}

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,144 +1,147 @@
 .hero {
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
-  align-items: center;
-  gap: clamp(2rem, 6vw, 3rem);
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: clamp(2.6rem, 7vh, 5.2rem) clamp(1.8rem, 4vw, 2.8rem) clamp(2.2rem, 6vh, 4.2rem);
-  min-height: clamp(520px, 78vh, 840px);
   height: 100%;
-}
-
-.hero__visual {
-  position: relative;
-  border-radius: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2.4rem, 7vh, 4.4rem) clamp(1.6rem, 4vw, 2.8rem);
   overflow: hidden;
-  min-height: clamp(320px, 48vh, 600px);
-  box-shadow: 0 30px 65px rgba(31, 39, 67, 0.32);
 }
 
-.hero__image {
+.hero__background {
+  position: absolute;
+  inset: 0;
+}
+
+.hero__background img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  filter: saturate(0.8) brightness(0.95) blur(6px);
   transform: scale(1.08);
+  opacity: 0.55;
 }
 
-.hero__overlay {
+.hero__background-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(31, 39, 67, 0.75), rgba(101, 185, 182, 0.4));
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.94), rgba(101, 185, 182, 0.3));
+  backdrop-filter: blur(10px);
 }
 
-.hero__floating {
-  position: absolute;
+.hero__inner {
+  position: relative;
+  width: min(100%, 880px);
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-  padding: 1.4rem 1.8rem;
-  border-radius: 24px;
-  backdrop-filter: blur(18px);
-  background: rgba(255, 255, 255, 0.16);
-  color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
-}
-
-.hero__floating strong {
-  font-size: 1.05rem;
-  letter-spacing: 0.02em;
-}
-
-.hero__floating--left {
-  left: 8%;
-  bottom: 12%;
-}
-
-.hero__floating--right {
-  right: 7%;
-  top: 12%;
-}
-
-.hero__content {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: clamp(1.3rem, 3.6vh, 1.9rem);
+  align-items: center;
+  gap: clamp(1rem, 3vh, 1.8rem);
+  padding: clamp(2.6rem, 7vh, 3.8rem) clamp(1.8rem, 5vw, 3.6rem);
+  border-radius: 40px;
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(22px);
+  box-shadow: 0 38px 90px rgba(16, 20, 49, 0.2);
+  text-align: center;
 }
 
 .hero__badge {
-  align-self: flex-start;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  background: rgba(101, 185, 182, 0.16);
-  color: var(--color-primary);
-  padding: 0.5rem 1.6rem;
+  gap: 0.45rem;
+  padding: 0.55rem 1.6rem;
   border-radius: 999px;
+  background: rgba(79, 93, 140, 0.1);
+  color: var(--color-dark);
   font-weight: 700;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero__logo {
+  width: clamp(96px, 14vw, 126px);
+  height: clamp(96px, 14vw, 126px);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #65b9b6, #4f5d8c);
+  box-shadow: 0 28px 55px rgba(79, 93, 140, 0.35);
+}
+
+.hero__logo svg {
+  width: 64%;
+  height: 64%;
 }
 
 .hero__title {
-  font-size: clamp(2.6rem, 4.4vw, 4.6rem);
-  margin: clamp(1.2rem, 3vh, 1.8rem) 0 clamp(0.9rem, 2.6vh, 1.2rem);
+  margin: 0;
+  font-size: clamp(2.8rem, 5vw, 4.2rem);
   font-weight: 800;
-  line-height: 1.12;
+  letter-spacing: -0.01em;
   color: var(--color-dark);
 }
 
 .hero__subtitle {
-  font-size: clamp(0.98rem, 1.5vw, 1.15rem);
+  margin: 0;
+  font-size: clamp(1.2rem, 1.9vw, 1.5rem);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(16, 20, 49, 0.6);
+}
+
+.hero__description {
+  margin: 0;
+  max-width: 560px;
   color: var(--color-muted);
-  max-width: 520px;
   line-height: 1.8;
 }
 
-.hero__features {
-  margin: clamp(1.4rem, 4vh, 2.2rem) 0 clamp(1.6rem, 4.6vh, 2.8rem);
-  padding: 0;
+.hero__highlights {
+  width: 100%;
   list-style: none;
+  margin: clamp(0.6rem, 2vh, 1rem) 0 0;
+  padding: 0;
   display: grid;
-  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 2.8vh, 1.4rem);
 }
 
-.hero__features li {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.8rem;
-  font-weight: 600;
+.hero__highlights li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1.6rem 1.8rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  text-align: left;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero__highlights h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
   color: var(--color-dark);
-  background: rgba(255, 255, 255, 0.7);
-  padding: 0.8rem 1.4rem;
-  border-radius: 999px;
-  box-shadow: 0 12px 30px rgba(80, 104, 146, 0.1);
 }
 
-.hero__features li::before {
-  content: '';
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--color-primary);
-  box-shadow: 0 0 0 5px rgba(101, 185, 182, 0.2);
+.hero__highlights p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.6;
 }
 
 .hero__actions {
   display: flex;
-  align-items: center;
-  gap: 1rem;
   flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.9rem;
 }
 
 .hero__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.6rem;
   padding: 0.95rem 2.4rem;
   border-radius: 999px;
   font-weight: 700;
@@ -156,140 +159,77 @@
 }
 
 .hero__cta:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 26px 50px rgba(79, 93, 140, 0.45);
+  transform: translateY(-4px);
+  box-shadow: 0 28px 55px rgba(79, 93, 140, 0.4);
 }
 
-.hero__pets {
+.hero__facts {
+  width: 100%;
+  margin: clamp(0.4rem, 1.6vh, 0.8rem) 0 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 1rem;
-  margin-top: clamp(2rem, 5vh, 3.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(0.8rem, 2vh, 1.1rem);
 }
 
-.hero__pet {
-  height: 160px;
-  border-radius: 22px;
-  object-fit: cover;
-  box-shadow: var(--shadow-soft);
-  transition: transform 0.35s ease;
+.hero__fact {
+  border-radius: 20px;
+  background: rgba(16, 20, 49, 0.05);
+  padding: 1rem 1.4rem;
+  text-align: left;
 }
 
-.hero__pet:hover {
-  transform: translateY(-6px);
+.hero__fact dt {
+  margin: 0 0 0.4rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(16, 20, 49, 0.55);
 }
 
-@media (max-width: 1100px) {
-  .hero {
+.hero__fact dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-dark);
+}
+
+@media (max-width: 900px) {
+  .hero__inner {
+    padding: clamp(2.4rem, 7vh, 3.4rem) clamp(1.6rem, 5vw, 2.6rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .hero__inner {
+    border-radius: 32px;
+    gap: clamp(0.8rem, 2.8vh, 1.4rem);
+  }
+
+  .hero__highlights {
     grid-template-columns: 1fr;
-    padding: clamp(2.6rem, 7vh, 4.6rem) clamp(1.6rem, 4vw, 2.4rem);
   }
 
-  .hero__visual {
-    min-height: clamp(320px, 50vh, 520px);
-    order: 2;
-  }
-
-  .hero__content {
-    align-items: flex-start;
-  }
-}
-
-@media (max-height: 820px) {
-  .hero {
+  .hero__facts {
     grid-template-columns: 1fr;
-    align-items: flex-start;
-    padding: clamp(2.2rem, 6vh, 4rem) clamp(1.6rem, 4vw, 2.4rem);
-    gap: clamp(1.5rem, 5vh, 2.4rem);
-  }
-
-  .hero__visual {
-    order: 2;
-    min-height: clamp(280px, 46vh, 400px);
-  }
-
-  .hero__content {
-    order: 1;
-    gap: clamp(1rem, 3vh, 1.6rem);
-  }
-
-  .hero__pets {
-    margin-top: clamp(1.6rem, 4vh, 2.4rem);
   }
 }
 
 @media (max-height: 700px) {
   .hero {
-    padding: clamp(1.8rem, 5.4vh, 3.2rem) clamp(1.4rem, 4vw, 2rem);
-    gap: clamp(1.3rem, 5vh, 2rem);
+    padding: clamp(1.8rem, 5vh, 3rem) clamp(1.4rem, 4vw, 2.2rem);
   }
 
-  .hero__title {
-    font-size: clamp(2.3rem, 5.6vw, 3.4rem);
-  }
-
-  .hero__subtitle {
-    font-size: clamp(0.95rem, 1.4vw, 1.05rem);
-    line-height: 1.6;
-  }
-
-  .hero__features {
-    margin-bottom: clamp(1.2rem, 3vh, 1.8rem);
-  }
-
-  .hero__pets {
-    display: none;
+  .hero__inner {
+    padding: clamp(2rem, 6vh, 3rem) clamp(1.6rem, 4vw, 2.4rem);
   }
 }
 
-@media (max-width: 640px) {
-  .hero {
-    padding: clamp(2rem, 7vh, 3.4rem) clamp(1.3rem, 5vw, 1.8rem);
-  }
-
-  .hero__features {
-    gap: 0.65rem;
-  }
-
-  .hero__features li {
-    padding: 0.7rem 1.2rem;
-  }
-
-  .hero__visual {
-    min-height: clamp(240px, 48vh, 380px);
-  }
-
-  .hero__pets {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-height: 640px) {
+@media (max-height: 600px) {
   .hero__badge {
     display: none;
   }
 
-  .hero__features {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.6rem;
-  }
-
-  .hero__features li {
-    justify-content: center;
-  }
-}
-
-@media (max-height: 560px) {
-  .hero__features {
+  .hero__facts {
     display: none;
-  }
-
-  .hero__subtitle {
-    font-size: clamp(0.92rem, 1.3vw, 1rem);
-  }
-
-  .hero {
-    padding-top: clamp(1.6rem, 4vh, 2.4rem);
   }
 }

--- a/src/styles/services.css
+++ b/src/styles/services.css
@@ -2,14 +2,18 @@
   padding: clamp(3.2rem, 8.6vh, 5.4rem) clamp(1.6rem, 4vw, 2.2rem);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.6), rgba(101, 185, 182, 0.05));
   display: flex;
-  flex-direction: column;
   justify-content: center;
+}
+
+.services__frame {
+  width: min(100%, 1120px);
+  display: flex;
+  flex-direction: column;
   gap: clamp(2rem, 5vh, 3.2rem);
 }
 
 .services__intro {
-  max-width: 1100px;
-  margin: 0 auto clamp(2.4rem, 6vh, 3.6rem);
+  width: 100%;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
   gap: clamp(1.8rem, 5vw, 2.5rem);
@@ -153,11 +157,13 @@
 @media (max-height: 860px) {
   .services {
     padding: clamp(2.6rem, 7.4vh, 4.6rem) clamp(1.4rem, 4vw, 2rem);
+  }
+
+  .services__frame {
     gap: clamp(1.6rem, 4.8vh, 2.6rem);
   }
 
   .services__intro {
-    margin-bottom: clamp(1.8rem, 4.6vh, 2.8rem);
     grid-template-columns: minmax(0, 1fr);
     gap: clamp(1.4rem, 4vh, 2rem);
   }
@@ -175,6 +181,9 @@
 @media (max-height: 720px) {
   .services {
     padding: clamp(2.2rem, 6vh, 3.8rem) clamp(1.3rem, 3.6vw, 1.8rem);
+  }
+
+  .services__frame {
     gap: clamp(1.4rem, 4vh, 2.2rem);
   }
 


### PR DESCRIPTION
## Summary
- Rebuild the hero section with centered branding, updated highlights, and fact tiles for a focused first impression
- Refresh text, imagery, and layout spacing across services, experience, gallery, inquiry, map, and footer sections to keep content within the viewport
- Add shared heading and badge styles to maintain consistent section framing

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68dcb7a4e7c4832db7db06b834018653